### PR TITLE
Update Azure Monitor webhook handler to report 'Fired' events instead…

### DIFF
--- a/codebundles/azure-monitor-webhook-handler/runbook.robot
+++ b/codebundles/azure-monitor-webhook-handler/runbook.robot
@@ -186,5 +186,5 @@ Start RunSession From Azure Monitor Webhook Details
             END
         END
     ELSE
-        RW.Core.Add To Report    Problem state '${WEBHOOK_JSON["state"]}' – handler only processes OPEN events.
+        RW.Core.Add To Report    Problem state '${monitor_condition}' – handler only processes Fired events.
     END


### PR DESCRIPTION
… missing state field.