### PR TITLE
Enhance ACR login handling in helm_update.sh and rwl_codecollection_updates.sh

### DIFF
--- a/codebundles/azure-rw-acr-helm-update/helm_update.sh
+++ b/codebundles/azure-rw-acr-helm-update/helm_update.sh
@@ -38,7 +38,10 @@ fi
 # Set the subscription to the determined ID
 echo "Switching to subscription ID: $subscription"
 az account set --subscription "$subscription" || { echo "Failed to set subscription."; exit 1; }
-az acr login -n "$REGISTRY_NAME"
+
+# Attempt ACR login (optional - not required since we use service principal auth)
+# Using || true to make it non-blocking if Docker is not available
+az acr login -n "$REGISTRY_NAME" 2>/dev/null || echo "Note: Direct ACR login not available (Docker not installed), using service principal authentication"
 
 # ===================================
 # Helper Functions

--- a/codebundles/azure-rw-acr-sync/rwl_codecollection_updates.sh
+++ b/codebundles/azure-rw-acr-sync/rwl_codecollection_updates.sh
@@ -48,12 +48,14 @@ fi
 echo "Switching to subscription ID: $subscription"
 az account set --subscription "$subscription" || { echo "Failed to set subscription."; exit 1; }
 
-# Ensure Docker credentials are set to avoid throttling
+# Ensure Docker credentials are set to avoid throttling (for source registries like Docker Hub)
 if [[ -z "$docker_username" || -z "$docker_token" ]]; then
     echo "Warning: Docker credentials (DOCKER_USERNAME and DOCKER_TOKEN) should be set to avoid throttling."
 fi
 
-az acr login -n "$private_registry"
+# Attempt ACR login (optional - not required since we use service principal auth)
+# Using || true to make it non-blocking if Docker is not available
+az acr login -n "$private_registry" 2>/dev/null || echo "Note: Direct ACR login not available (Docker not installed), using service principal authentication"
 
 # ===================================
 # CodeCollection Image Definitions


### PR DESCRIPTION
- Updated ACR login commands to be non-blocking if Docker is not installed, improving script resilience.
- Added informative messages to indicate when direct ACR login is unavailable, ensuring clarity for users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make ACR login attempts optional and non-blocking with clear messaging; clarify Docker creds warning for source registries.
> 
> - **Scripts**:
>   - `codebundles/azure-rw-acr-helm-update/helm_update.sh`:
>     - Make `az acr login -n "$REGISTRY_NAME"` optional/non-blocking (stderr suppressed) with fallback message indicating service principal auth.
>   - `codebundles/azure-rw-acr-sync/rwl_codecollection_updates.sh`:
>     - Make `az acr login -n "$private_registry"` optional/non-blocking (stderr suppressed) with fallback message indicating service principal auth.
>     - Clarify Docker throttling warning to apply to source registries (e.g., Docker Hub).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d47b80489cbd275fbd8e29be0c17151d338aa90b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->