### PR TITLE
Update requirements and enhance SLX task management

### DIFF
--- a/codebundles/cron-scheduler-sli/EXAMPLE.md
+++ b/codebundles/cron-scheduler-sli/EXAMPLE.md
@@ -1,0 +1,192 @@
+# Cron Scheduler SLI - Configuration Examples
+
+This document provides practical examples of how to configure the Cron Scheduler SLI for various use cases.
+
+## Two Main Usage Patterns
+
+### Pattern 1: Self-Scheduling (No TARGET_SLX)
+The SLI triggers the runbook of the same SLX it's attached to. This is the simplest and most common pattern.
+- Just set `CRON_SCHEDULE`
+- The SLI automatically uses the current SLX
+- Perfect for scheduled maintenance, reports, backups, etc.
+
+### Pattern 2: Cross-SLX Scheduling (With TARGET_SLX)
+The SLI triggers a different SLX's runbook. Useful for centralized scheduling.
+- Set both `CRON_SCHEDULE` and `TARGET_SLX`
+- The SLI acts as a scheduler that triggers other SLXs
+- Perfect for orchestrating multiple workflows
+
+## Example 1: Self-Scheduling SLI (Triggers Its Own Runbook)
+
+The simplest configuration - the SLI triggers the runbook of the SLX it's attached to:
+
+### SLI Configuration
+```yaml
+CRON_SCHEDULE: "0 * * * *"
+DRY_RUN: "false"
+```
+
+### What This Does
+- Runs every hour at minute 0 (e.g., 1:00, 2:00, 3:00)
+- Automatically uses the SLX this SLI is attached to (no TARGET_SLX needed)
+- Automatically detects the SLI's run interval from the SLX spec
+- Executes all tasks from the current SLX's runbook
+- Perfect for scheduled maintenance tasks where the SLI and runbook are in the same SLX
+
+## Example 2: Triggering a Different SLX
+
+Schedule a database backup by triggering a different SLX:
+
+### SLI Configuration
+```yaml
+CRON_SCHEDULE: "0 * * * *"
+TARGET_SLX: "postgres-backup-slx"
+DRY_RUN: "false"
+```
+
+### What This Does
+- Runs every hour at minute 0
+- Executes all tasks from the `postgres-backup-slx` runbook (different from the SLX this SLI is in)
+- Automatically detects the SLI's run interval
+- Useful when you have a central scheduler SLX that triggers other SLXs
+
+## Example 3: Business Hours Health Check (Self-Scheduling)
+
+Run health checks every 15 minutes during business hours (9 AM - 5 PM, Monday-Friday):
+
+### SLI Configuration
+```yaml
+CRON_SCHEDULE: "*/15 9-17 * * 1-5"
+DRY_RUN: "false"
+```
+
+### What This Does
+- Runs every 15 minutes (at :00, :15, :30, :45) between 9 AM and 5 PM
+- Only on weekdays (Monday=1 through Friday=5)
+- Uses the current SLX (no TARGET_SLX needed)
+- Executes the health check runbook during business hours only
+
+## Example 4: Daily Report at 9 AM (Self-Scheduling)
+
+Generate a daily report every morning at 9:00 AM:
+
+### SLI Configuration
+```yaml
+CRON_SCHEDULE: "0 9 * * *"
+DRY_RUN: "false"
+```
+
+### What This Does
+- Runs once per day at 9:00 AM UTC
+- Uses the current SLX's runbook
+- Perfect for morning reports, daily summaries, etc.
+
+## Example 5: Weekly Cleanup on Sundays (Self-Scheduling)
+
+Run cleanup tasks every Sunday at midnight:
+
+### SLI Configuration
+```yaml
+CRON_SCHEDULE: "0 0 * * 0"
+DRY_RUN: "false"
+```
+
+### What This Does
+- Runs once per week on Sunday (0) at midnight (00:00)
+- Uses the current SLX's runbook
+- Executes cleanup tasks like log rotation, temporary file cleanup, etc.
+
+## Example 6: Every 5 Minutes Monitoring
+
+Frequent monitoring check every 5 minutes:
+
+### SLI Configuration
+```yaml
+CRON_SCHEDULE: "*/5 * * * *"
+TARGET_SLX: "critical-service-monitor-slx"
+DRY_RUN: "false"
+```
+
+### What This Does
+- Runs every 5 minutes (at :00, :05, :10, :15, :20, :25, :30, :35, :40, :45, :50, :55)
+- Executes monitoring checks for critical services
+- Provides frequent status updates
+
+## Example 7: Monthly Report on First Day
+
+Generate a monthly report on the 1st of each month at 8:00 AM:
+
+### SLI Configuration
+```yaml
+CRON_SCHEDULE: "0 8 1 * *"
+TARGET_SLX: "monthly-report-slx"
+DRY_RUN: "false"
+```
+
+### What This Does
+- Runs once per month on the 1st day at 8:00 AM
+- Perfect for monthly billing reports, usage summaries, etc.
+
+## Example 8: Testing a New Schedule (Dry Run)
+
+Before enabling a new schedule, test it first:
+
+### SLI Configuration
+```yaml
+CRON_SCHEDULE: "30 */2 * * *"
+TARGET_SLX: "new-maintenance-task-slx"
+DRY_RUN: "true"
+```
+
+### What This Does
+- Tests the schedule "30 */2 * * *" (every 2 hours at :30)
+- Reports what would happen without actually executing the runbook
+- Shows the next scheduled run time
+- Validates the cron expression
+
+### After Testing
+Once you've verified the schedule is correct, change `DRY_RUN` to `"false"` to enable execution.
+
+## Understanding the Timing Window
+
+The `RUN_INTERVAL_SECONDS` parameter is important:
+
+- If your SLI runs every 60 seconds, set `RUN_INTERVAL_SECONDS: "60"`
+- The SLI will trigger if the current time is within this window of a scheduled time
+- Example: With a 60-second window and schedule "0 * * * *" (hourly):
+  - If the SLI runs at 3:00:30, it will trigger (30 seconds after 3:00:00)
+  - If the SLI runs at 3:01:30, it won't trigger (90 seconds after 3:00:00)
+
+## Troubleshooting
+
+### Schedule Not Triggering
+
+1. Check the SLI report for the "Next scheduled run" time
+2. Verify your cron expression is valid
+3. Ensure `RUN_INTERVAL_SECONDS` matches your SLI's actual run interval
+4. Remember that cron schedules use UTC time
+
+### Wrong SLX or Missing TARGET_SLX
+
+If you see "Failed to trigger runbook execution" or "Could not determine TARGET_SLX":
+1. If using TARGET_SLX, verify the short name is correct
+2. If not using TARGET_SLX, ensure the SLI is attached to an SLX
+3. Check that the target SLX exists in your workspace
+4. Ensure the target SLX has a runbook configured
+
+## Advanced Patterns
+
+### Multiple Schedules for the Same SLX
+
+If you need multiple schedules, create multiple SLI instances with different cron expressions:
+
+- SLI 1: `CRON_SCHEDULE: "0 9 * * *"` (morning run)
+- SLI 2: `CRON_SCHEDULE: "0 17 * * *"` (evening run)
+- Both targeting the same `TARGET_SLX`
+
+### Coordinating Multiple Tasks
+
+To run multiple different tasks on the same schedule:
+1. Create a "coordinator" runbook that calls other runbooks
+2. Set that as your `TARGET_SLX`
+3. The coordinator runbook can then trigger multiple other SLXs in sequence

--- a/codebundles/cron-scheduler-sli/README.md
+++ b/codebundles/cron-scheduler-sli/README.md
@@ -1,0 +1,184 @@
+# Cron Scheduler SLI
+
+A generic SLI codebundle that functions as a cron scheduler, allowing you to run a runbook on a regular schedule based on cron expressions.
+
+## Overview
+
+This SLI runs on a regular interval (typically every 60 seconds) and checks if the current time matches a configured cron schedule. When the schedule matches (within the run interval window), it automatically executes all tasks from the runbook attached to a specified SLX.
+
+## Use Cases
+
+- **Scheduled Maintenance**: Run maintenance tasks at specific times (e.g., "0 2 * * *" for 2 AM daily)
+- **Periodic Health Checks**: Execute health checks at regular intervals (e.g., "*/15 * * * *" for every 15 minutes)
+- **Hourly Reports**: Generate reports on the hour (e.g., "0 * * * *")
+- **Weekly Cleanup**: Run cleanup tasks weekly (e.g., "0 0 * * 0" for Sunday midnight)
+- **Business Hours Automation**: Run tasks only during business hours (e.g., "0 9-17 * * 1-5" for 9 AM-5 PM weekdays)
+
+## How It Works
+
+1. The SLI runs at its configured interval (default: every 60 seconds)
+2. On each run, it checks if the current time matches the cron schedule
+3. If the time matches (within the run interval window), it:
+   - Looks up the runbook attached to the target SLX (or current SLX if TARGET_SLX not specified)
+   - Executes all tasks from that runbook
+   - Pushes a metric indicating success or failure
+4. If the time doesn't match, it reports the next scheduled run time
+
+## Usage Patterns
+
+### Self-Scheduling (Most Common)
+The simplest pattern - the SLI triggers its own runbook:
+- Don't specify `TARGET_SLX` (leave it empty)
+- The SLI automatically uses the SLX it's attached to
+- Perfect for scheduled tasks where the SLI and runbook are together
+
+### Cross-SLX Scheduling
+For more complex orchestration:
+- Specify `TARGET_SLX` to trigger a different SLX's runbook
+- Useful for centralized scheduling or coordinating multiple workflows
+
+## Configuration
+
+### Required Variables
+
+- **CRON_SCHEDULE** - The cron schedule expression
+  - Format: Standard 5-field cron expression (minute hour day month weekday)
+  - Example: `0 */2 * * *` (every 2 hours at minute 0)
+  - Example: `*/15 * * * *` (every 15 minutes)
+  - Example: `0 9 * * 1-5` (9 AM on weekdays)
+  - Default: `0 * * * *` (every hour)
+
+### Optional Variables
+
+- **TARGET_SLX** - The short name of the target SLX whose runbook should be executed
+  - This is the SLX shortName (not the full name with workspace prefix)
+  - **If not provided, uses the current SLX** (the SLX this SLI is attached to)
+  - This allows the SLI to trigger its own runbook on a schedule
+  - Example: `my-maintenance-slx`
+  - Default: Current SLX (auto-detected)
+
+- **DRY_RUN** - Set to `true` to test without executing the runbook (default: `false`)
+  - When enabled, the SLI will check the schedule and report what would happen
+  - Useful for testing cron expressions before enabling execution
+
+## Cron Expression Format
+
+The cron schedule uses the standard 5-field format:
+
+```
+* * * * *
+│ │ │ │ │
+│ │ │ │ └─── Day of week (0-6, Sunday=0)
+│ │ │ └───── Month (1-12)
+│ │ └─────── Day of month (1-31)
+│ └───────── Hour (0-23)
+└─────────── Minute (0-59)
+```
+
+### Common Examples
+
+- `0 * * * *` - Every hour at minute 0
+- `*/15 * * * *` - Every 15 minutes
+- `0 */2 * * *` - Every 2 hours
+- `0 9 * * *` - Every day at 9 AM
+- `0 9 * * 1-5` - Every weekday at 9 AM
+- `0 0 * * 0` - Every Sunday at midnight
+- `30 14 1 * *` - 2:30 PM on the 1st of every month
+- `0 9-17 * * 1-5` - Every hour from 9 AM to 5 PM on weekdays
+
+## Metrics
+
+The SLI pushes a metric with the following values:
+
+- **1** - Runbook was successfully executed
+- **0** - Not time to run yet (schedule not matched)
+- **-1** - Execution failed (runbook trigger failed)
+
+You can use these metrics to:
+- Monitor successful executions
+- Alert on execution failures
+- Track scheduling accuracy
+
+## Example Configurations
+
+### Self-Scheduling (Simple)
+
+```yaml
+CRON_SCHEDULE: "0 * * * *"
+DRY_RUN: "false"
+```
+
+This will execute the current SLX's runbook every hour at minute 0.
+
+### Cross-SLX Scheduling
+
+```yaml
+CRON_SCHEDULE: "0 * * * *"
+TARGET_SLX: "database-maintenance"
+DRY_RUN: "false"
+```
+
+This will execute the `database-maintenance` SLX's runbook every hour at minute 0.
+
+### Daily Report at 9 AM
+
+```yaml
+CRON_SCHEDULE: "0 9 * * *"
+TARGET_SLX: "daily-report-generator"
+RUN_INTERVAL_SECONDS: "60"
+DRY_RUN: "false"
+```
+
+This will execute the `daily-report-generator` runbook every day at 9:00 AM.
+
+### Every 15 Minutes Health Check
+
+```yaml
+CRON_SCHEDULE: "*/15 * * * *"
+TARGET_SLX: "service-health-check"
+RUN_INTERVAL_SECONDS: "60"
+DRY_RUN: "false"
+```
+
+This will execute the `service-health-check` runbook every 15 minutes.
+
+## Testing
+
+To test your cron schedule without executing the runbook:
+
+1. Set `DRY_RUN: "true"`
+2. Run the SLI and check the report
+3. Verify the cron schedule is valid and the next run time is correct
+4. Once confirmed, set `DRY_RUN: "false"` to enable execution
+
+## Notes
+
+- The SLI checks if the current time is within `RUN_INTERVAL_SECONDS` of a scheduled cron time
+- This means if your SLI runs every 60 seconds, it will trigger if within 60 seconds of the scheduled time
+- Ensure your `RUN_INTERVAL_SECONDS` matches your actual SLI run interval for accurate scheduling
+- The cron schedule uses UTC time by default
+- Invalid cron expressions will cause the SLI to fail with an error message
+
+## Troubleshooting
+
+### Runbook Not Executing
+
+- Verify the `TARGET_SLX` short name is correct
+- Check that the target SLX has a runbook configured
+- Ensure the SLI has permissions to execute tasks in the workspace
+- Review the SLI report for error messages
+
+### Schedule Not Matching
+
+- Verify your cron expression is valid using the "Validate Cron Schedule" output
+- Check the "Next scheduled run" time in the report
+- Check the "Detected SLI interval" in the report to see what interval was auto-detected
+- Remember that cron schedules use UTC time
+
+### Testing Cron Expressions
+
+Use `DRY_RUN: "true"` to test your cron expression:
+- The SLI will validate the expression
+- It will show the next scheduled run time
+- It will report whether the current time matches
+- No runbook execution will occur

--- a/codebundles/cron-scheduler-sli/sli.robot
+++ b/codebundles/cron-scheduler-sli/sli.robot
@@ -53,8 +53,8 @@ Suite Initialization
     
     Set Suite Variable    ${TARGET_SLX}    ${TARGET_SLX}
 
-    # Get the SLI interval from the SLX spec automatically
-    ${RUN_INTERVAL_SECONDS}=    RW.Workspace.Get Current SLI Interval Seconds
+    # Get the SLI interval from the SLX spec automatically (pass TARGET_SLX)
+    ${RUN_INTERVAL_SECONDS}=    RW.Workspace.Get Current SLI Interval Seconds    ${TARGET_SLX}
     RW.Core.Add To Report    Detected SLI interval: ${RUN_INTERVAL_SECONDS} seconds
     Set Suite Variable    ${RUN_INTERVAL_SECONDS}    ${RUN_INTERVAL_SECONDS}
 

--- a/codebundles/cron-scheduler-sli/sli.robot
+++ b/codebundles/cron-scheduler-sli/sli.robot
@@ -29,7 +29,7 @@ Suite Initialization
     ...    description=The short name of the target SLX whose runbook should be executed when the cron schedule matches. If empty, uses the current SLX (the SLX this SLI is attached to).
     ...    pattern=\w*
     ...    example=my-slx-shortname
-    ...    default=''
+    ...    default=${EMPTY}
     
     # If TARGET_SLX is not provided, use the current SLX
     ${target_slx_empty}=    Run Keyword And Return Status    Should Be Empty    ${TARGET_SLX}

--- a/codebundles/cron-scheduler-sli/sli.robot
+++ b/codebundles/cron-scheduler-sli/sli.robot
@@ -36,7 +36,7 @@ Suite Initialization
     IF    ${target_slx_empty}
         ${TARGET_SLX}=    RW.Workspace.Get Current SLX Short Name
         ${still_empty}=    Run Keyword And Return Status    Should Be Empty    ${TARGET_SLX}
-        IF    ${still_empty} or $TARGET_SLX == 'None'
+        IF    ${still_empty} or $TARGET_SLX is None
             RW.Core.Add Issue
             ...    severity=2
             ...    expected=TARGET_SLX should be provided or SLI should be attached to an SLX

--- a/codebundles/cron-scheduler-sli/sli.robot
+++ b/codebundles/cron-scheduler-sli/sli.robot
@@ -32,9 +32,11 @@ Suite Initialization
     ...    default=''
     
     # If TARGET_SLX is not provided, use the current SLX
-    IF    '${TARGET_SLX}' == '${EMPTY}' or '${TARGET_SLX}' == ''
+    ${target_slx_empty}=    Run Keyword And Return Status    Should Be Empty    ${TARGET_SLX}
+    IF    ${target_slx_empty}
         ${TARGET_SLX}=    RW.Workspace.Get Current SLX Short Name
-        IF    '${TARGET_SLX}' == 'None' or '${TARGET_SLX}' == ''
+        ${still_empty}=    Run Keyword And Return Status    Should Be Empty    ${TARGET_SLX}
+        IF    ${still_empty} or $TARGET_SLX == 'None'
             RW.Core.Add Issue
             ...    severity=2
             ...    expected=TARGET_SLX should be provided or SLI should be attached to an SLX

--- a/codebundles/cron-scheduler-sli/sli.robot
+++ b/codebundles/cron-scheduler-sli/sli.robot
@@ -1,0 +1,135 @@
+*** Settings ***
+Documentation       Generic Cron Scheduler SLI that runs a runbook on a cron schedule.
+...                 This SLI checks if the current time matches the configured cron schedule,
+...                 and if so, executes all tasks from the runbook attached to the specified SLX.
+Metadata            Author    stewartshea
+Metadata            Display Name    Cron Scheduler SLI
+Metadata            Supports    Generic    Cron    Scheduler    Workspace
+
+Library             BuiltIn
+Library             RW.Core
+Library             RW.Workspace
+Library             RW.Cron
+Library             OperatingSystem
+
+Suite Setup         Suite Initialization
+
+*** Keywords ***
+Suite Initialization
+    ${CRON_SCHEDULE}=    RW.Core.Import User Variable    CRON_SCHEDULE
+    ...    type=string
+    ...    description=Cron schedule expression (e.g., "0 */2 * * *" for every 2 hours, "*/15 * * * *" for every 15 minutes)
+    ...    pattern=\w*
+    ...    example=0 */2 * * *
+    ...    default=0 * * * *
+    Set Suite Variable    ${CRON_SCHEDULE}    ${CRON_SCHEDULE}
+
+    ${TARGET_SLX}=    RW.Core.Import User Variable    TARGET_SLX
+    ...    type=string
+    ...    description=The short name of the target SLX whose runbook should be executed when the cron schedule matches. If empty, uses the current SLX (the SLX this SLI is attached to).
+    ...    pattern=\w*
+    ...    example=my-slx-shortname
+    ...    default=''
+    
+    # If TARGET_SLX is not provided, use the current SLX
+    IF    '${TARGET_SLX}' == '${EMPTY}' or '${TARGET_SLX}' == ''
+        ${TARGET_SLX}=    RW.Workspace.Get Current SLX Short Name
+        IF    '${TARGET_SLX}' == 'None' or '${TARGET_SLX}' == ''
+            RW.Core.Add Issue
+            ...    severity=2
+            ...    expected=TARGET_SLX should be provided or SLI should be attached to an SLX
+            ...    actual=Could not determine TARGET_SLX from configuration or current SLX context
+            ...    title=Cron Scheduler Configuration Error - Missing TARGET_SLX
+            ...    reproduce_hint=Provide TARGET_SLX parameter or ensure this SLI is properly attached to an SLX
+            ...    details=The cron scheduler could not determine which SLX runbook to execute. Either specify TARGET_SLX explicitly or attach this SLI to an SLX.
+            ...    next_steps=Add TARGET_SLX parameter to the SLI configuration, or verify the SLI is attached to an SLX with a runbook.
+            RW.Core.Push Metric    -1
+            Return From Keyword
+        END
+        RW.Core.Add To Report    Using current SLX: ${TARGET_SLX}
+    END
+    
+    Set Suite Variable    ${TARGET_SLX}    ${TARGET_SLX}
+
+    # Get the SLI interval from the SLX spec automatically
+    ${RUN_INTERVAL_SECONDS}=    RW.Workspace.Get Current SLI Interval Seconds
+    RW.Core.Add To Report    Detected SLI interval: ${RUN_INTERVAL_SECONDS} seconds
+    Set Suite Variable    ${RUN_INTERVAL_SECONDS}    ${RUN_INTERVAL_SECONDS}
+
+    ${DRY_RUN}=    RW.Core.Import User Variable    DRY_RUN
+    ...    type=string
+    ...    description=If true, only check the cron schedule and report but don't execute the runbook
+    ...    enum=[true,false]
+    ...    pattern=\w*
+    ...    default=false
+    Set Suite Variable    ${DRY_RUN}    ${DRY_RUN}
+
+*** Tasks ***
+Check Cron Schedule and Execute Runbook for SLX `${TARGET_SLX}`
+    [Documentation]    Check if the current time matches the cron schedule and execute the target SLX runbook if it does
+    [Tags]    cron    scheduler    sli    automation
+
+    # Validate the cron schedule
+    ${is_valid}=    RW.Cron.Validate Cron Schedule    ${CRON_SCHEDULE}
+    IF    not ${is_valid}
+        RW.Core.Add To Report    ERROR: Invalid cron schedule: ${CRON_SCHEDULE}
+        RW.Core.Add Issue
+        ...    severity=2
+        ...    expected=Valid cron schedule expression in standard 5-field format
+        ...    actual=Invalid cron schedule: ${CRON_SCHEDULE}
+        ...    title=Cron Scheduler Configuration Error - Invalid Cron Expression
+        ...    reproduce_hint=Check the CRON_SCHEDULE parameter syntax (format: minute hour day month weekday)
+        ...    details=The provided cron schedule "${CRON_SCHEDULE}" is not a valid cron expression. Use standard 5-field cron syntax (e.g., "0 */2 * * *" for every 2 hours).
+        ...    next_steps=Update CRON_SCHEDULE to a valid cron expression. Examples: "0 * * * *" (hourly), "*/15 * * * *" (every 15 min), "0 9 * * 1-5" (9 AM weekdays).
+        RW.Core.Push Metric    -1
+        Return From Keyword
+    END
+
+    # Get the next scheduled run time for reporting
+    ${next_run}=    RW.Cron.Get Next Cron Run Time    ${CRON_SCHEDULE}
+    RW.Core.Add To Report    Cron schedule: ${CRON_SCHEDULE}
+    RW.Core.Add To Report    Next scheduled run: ${next_run}
+    RW.Core.Add To Report    Target SLX: ${TARGET_SLX}
+    RW.Core.Add To Report    Run interval: ${RUN_INTERVAL_SECONDS} seconds
+
+    # Check if the current time matches the cron schedule
+    ${is_time_to_run}=    RW.Cron.Check Cron Schedule Match    
+    ...    ${CRON_SCHEDULE}    
+    ...    ${RUN_INTERVAL_SECONDS}
+
+    IF    ${is_time_to_run}
+        RW.Core.Add To Report    ✓ Cron schedule matched! Time to execute runbook.
+        
+        IF    '${DRY_RUN}' == 'true'
+            RW.Core.Add To Report    DRY RUN MODE: Would execute runbook for SLX ${TARGET_SLX}
+            ${metric_value}=    Set Variable    0
+        ELSE
+            RW.Core.Add To Report    Creating new runsession for SLX ${TARGET_SLX}...
+            
+            # Create a new runsession with all tasks from the target SLX runbook
+            ${result}=    RW.Workspace.Create RunSession For SLX    ${TARGET_SLX}    cronScheduler
+            
+            IF    $result is not None
+                RW.Core.Add To Report    ✓ Successfully created runsession for SLX ${TARGET_SLX}
+                RW.Core.Add Pre To Report    RunSession:\n${result}
+                ${metric_value}=    Set Variable    1
+            ELSE
+                RW.Core.Add To Report    ✗ Failed to create runsession for SLX ${TARGET_SLX}
+                RW.Core.Add Issue
+                ...    severity=2
+                ...    expected=Successfully create runsession for SLX ${TARGET_SLX}
+                ...    actual=Failed to create runsession - API call returned None or failed
+                ...    title=Cron Scheduler Execution Failed for SLX ${TARGET_SLX}
+                ...    reproduce_hint=Verify the SLX "${TARGET_SLX}" exists and has a runbook configured
+                ...    details=The cron scheduler matched the schedule and attempted to create a runsession for SLX ${TARGET_SLX}, but the API request failed. This could be due to: SLX not found, no runbook configured, insufficient permissions, or API connectivity issues.
+                ...    next_steps=Verify SLX name "${TARGET_SLX}" is correct, check that the SLX exists in the workspace, ensure it has a runbook configured, and verify the SLI has permissions to create runsessions.
+                ${metric_value}=    Set Variable    -1
+            END
+        END
+    ELSE
+        RW.Core.Add To Report    Schedule not matched. Waiting for next scheduled time: ${next_run}
+        ${metric_value}=    Set Variable    0
+    END
+
+    # Push metric: 1 = runbook executed, 0 = not time yet, -1 = execution failed
+    RW.Core.Push Metric    ${metric_value}

--- a/libraries/RW/Cron/__init__.py
+++ b/libraries/RW/Cron/__init__.py
@@ -1,0 +1,7 @@
+"""
+Cron keyword library for cron schedule parsing and matching.
+
+Scope: GLOBAL
+"""
+
+from .cron_utils import *

--- a/libraries/RW/Cron/cron_utils.py
+++ b/libraries/RW/Cron/cron_utils.py
@@ -1,0 +1,175 @@
+"""
+Cron utilities for parsing and checking cron schedules.
+
+This module provides Robot Framework keywords for working with cron schedules.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+from robot.api.deco import keyword
+from robot.libraries.BuiltIn import BuiltIn
+
+try:
+    from croniter import croniter
+except ImportError:
+    croniter = None
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Module-level constants
+# ──────────────────────────────────────────────────────────────────────────────
+ROBOT_LIBRARY_SCOPE = "GLOBAL"
+
+
+@keyword("Check Cron Schedule Match")
+def check_cron_schedule_match(
+    cron_schedule: str,
+    interval_seconds: int = 60,
+    base_time: Optional[datetime] = None
+) -> bool:
+    """
+    Check if the current time matches the given cron schedule within the interval window.
+    
+    Args:
+        cron_schedule: A cron schedule expression (e.g., "0 */2 * * *" for every 2 hours)
+        interval_seconds: The run interval in seconds (default: 60). The check will pass
+                         if we're within this many seconds of a scheduled cron time.
+        base_time: Optional datetime to check against (defaults to current UTC time)
+    
+    Returns:
+        True if the current time is within interval_seconds of a scheduled cron time,
+        False otherwise.
+    
+    Example:
+        ${is_time}=    Check Cron Schedule Match    0 */2 * * *    60
+        IF    ${is_time}
+            Log    Time to run the scheduled task!
+        END
+    """
+    if croniter is None:
+        BuiltIn().log("croniter library not installed. Install with: pip install croniter", level="ERROR")
+        return False
+    
+    if not cron_schedule or not cron_schedule.strip():
+        BuiltIn().log("Empty cron schedule provided", level="WARN")
+        return False
+    
+    # Validate cron expression
+    if not croniter.is_valid(cron_schedule):
+        BuiltIn().log(f"Invalid cron schedule: {cron_schedule}", level="ERROR")
+        return False
+    
+    # Use provided time or current UTC time
+    if base_time is None:
+        base_time = datetime.now(timezone.utc)
+    
+    try:
+        # Create croniter instance
+        cron = croniter(cron_schedule, base_time)
+        
+        # Get the previous scheduled time
+        prev_time = cron.get_prev(datetime)
+        
+        # Calculate the difference in seconds
+        time_diff = abs((base_time - prev_time).total_seconds())
+        
+        # Also check the next scheduled time to handle edge cases where
+        # we're exactly at the scheduled time
+        cron_next = croniter(cron_schedule, base_time)
+        next_time = cron_next.get_next(datetime)
+        time_diff_next = abs((base_time - next_time).total_seconds())
+        
+        # Check if we're within the interval window of either prev or next
+        is_match = (time_diff <= interval_seconds) or (time_diff_next <= interval_seconds)
+        
+        if is_match:
+            BuiltIn().log(
+                f"Cron schedule matched! Schedule: {cron_schedule}, "
+                f"Last run time: {prev_time.isoformat()}, "
+                f"Current time: {base_time.isoformat()}, "
+                f"Difference: {time_diff:.1f}s (threshold: {interval_seconds}s)",
+                level="INFO"
+            )
+        else:
+            BuiltIn().log(
+                f"Cron schedule not matched. Schedule: {cron_schedule}, "
+                f"Last run time: {prev_time.isoformat()}, "
+                f"Current time: {base_time.isoformat()}, "
+                f"Difference: {time_diff:.1f}s (threshold: {interval_seconds}s)",
+                level="DEBUG"
+            )
+        
+        return is_match
+        
+    except Exception as e:
+        BuiltIn().log(f"Error checking cron schedule: {str(e)}", level="ERROR")
+        return False
+
+
+@keyword("Get Next Cron Run Time")
+def get_next_cron_run_time(
+    cron_schedule: str,
+    base_time: Optional[datetime] = None
+) -> Optional[str]:
+    """
+    Get the next scheduled run time for the given cron schedule.
+    
+    Args:
+        cron_schedule: A cron schedule expression
+        base_time: Optional datetime to calculate from (defaults to current UTC time)
+    
+    Returns:
+        ISO format string of the next run time, or None if there's an error
+    
+    Example:
+        ${next_run}=    Get Next Cron Run Time    0 */2 * * *
+        Log    Next scheduled run: ${next_run}
+    """
+    if croniter is None:
+        BuiltIn().log("croniter library not installed", level="ERROR")
+        return None
+    
+    if not cron_schedule or not cron_schedule.strip():
+        BuiltIn().log("Empty cron schedule provided", level="WARN")
+        return None
+    
+    if not croniter.is_valid(cron_schedule):
+        BuiltIn().log(f"Invalid cron schedule: {cron_schedule}", level="ERROR")
+        return None
+    
+    if base_time is None:
+        base_time = datetime.now(timezone.utc)
+    
+    try:
+        cron = croniter(cron_schedule, base_time)
+        next_time = cron.get_next(datetime)
+        return next_time.isoformat()
+    except Exception as e:
+        BuiltIn().log(f"Error getting next cron run time: {str(e)}", level="ERROR")
+        return None
+
+
+@keyword("Validate Cron Schedule")
+def validate_cron_schedule(cron_schedule: str) -> bool:
+    """
+    Validate if a cron schedule expression is valid.
+    
+    Args:
+        cron_schedule: A cron schedule expression to validate
+    
+    Returns:
+        True if valid, False otherwise
+    
+    Example:
+        ${is_valid}=    Validate Cron Schedule    0 */2 * * *
+        IF    not ${is_valid}
+            Fail    Invalid cron schedule provided
+        END
+    """
+    if croniter is None:
+        BuiltIn().log("croniter library not installed", level="ERROR")
+        return False
+    
+    if not cron_schedule or not cron_schedule.strip():
+        return False
+    
+    return croniter.is_valid(cron_schedule)

--- a/libraries/RW/Cron/cron_utils.py
+++ b/libraries/RW/Cron/cron_utils.py
@@ -72,14 +72,9 @@ def check_cron_schedule_match(
         # Calculate the difference in seconds
         time_diff = abs((base_time - prev_time).total_seconds())
         
-        # Also check the next scheduled time to handle edge cases where
-        # we're exactly at the scheduled time
-        cron_next = croniter(cron_schedule, base_time)
-        next_time = cron_next.get_next(datetime)
-        time_diff_next = abs((base_time - next_time).total_seconds())
-        
-        # Check if we're within the interval window of either prev or next
-        is_match = (time_diff <= interval_seconds) or (time_diff_next <= interval_seconds)
+        # Check if we're within the interval window AFTER the scheduled time
+        # This ensures we only trigger at or after the scheduled time, not before
+        is_match = time_diff <= interval_seconds
         
         if is_match:
             BuiltIn().log(

--- a/libraries/RW/Workspace/__init__.py
+++ b/libraries/RW/Workspace/__init__.py
@@ -1,1 +1,2 @@
 from .workspace_utils import *
+from .slx_utils import *

--- a/libraries/RW/Workspace/slx_utils.py
+++ b/libraries/RW/Workspace/slx_utils.py
@@ -110,8 +110,12 @@ def get_current_sli_interval_seconds() -> Optional[int]:
         if workspace_path.startswith('workspaces/'):
             workspace_path = workspace_path[len('workspaces/'):]
         
-        # Fetch the SLX details
-        slx_url = f"{root}/{workspace_path}/slxs/{slx_short_name}"
+        # Handle case where root might already include "/workspaces" suffix
+        base_url = root.rstrip('/')
+        if base_url.endswith('/workspaces'):
+            slx_url = f"{base_url}/{workspace_path}/slxs/{slx_short_name}"
+        else:
+            slx_url = f"{base_url}/workspaces/{workspace_path}/slxs/{slx_short_name}"
         
         try:
             response = sess.get(slx_url, timeout=120)

--- a/libraries/RW/Workspace/slx_utils.py
+++ b/libraries/RW/Workspace/slx_utils.py
@@ -1,0 +1,139 @@
+"""
+SLX utility functions for getting current SLX information.
+"""
+
+import os
+import json
+import requests
+from typing import Optional, Dict
+from robot.api.deco import keyword
+from robot.libraries.BuiltIn import BuiltIn
+
+
+@keyword("Get Current SLX Short Name")
+def get_current_slx_short_name() -> Optional[str]:
+    """
+    Get the short name of the current SLX from the runsession details.
+    
+    Returns the short name of the SLX that this SLI/runbook is attached to,
+    or None if it cannot be determined.
+    
+    Example:
+        ${current_slx}=    Get Current SLX Short Name
+        Log    Running in SLX: ${current_slx}
+    """
+    try:
+        # Try to get from environment variable first (if it exists)
+        slx_name = os.getenv("RW_SLX_NAME")
+        if slx_name:
+            # Remove workspace prefix if present (workspace--slxname -> slxname)
+            if "--" in slx_name:
+                return slx_name.split("--", 1)[1]
+            return slx_name
+        
+        # Fall back to getting from runsession details
+        from RW.Workspace.workspace_utils import import_runsession_details
+        
+        runsession_json = import_runsession_details()
+        if not runsession_json:
+            BuiltIn().log("Could not retrieve runsession details", level="WARN")
+            return None
+        
+        runsession = json.loads(runsession_json)
+        
+        # Get the most recent runRequest
+        run_requests = runsession.get("runRequests", [])
+        if not run_requests:
+            BuiltIn().log("No runRequests found in runsession", level="WARN")
+            return None
+        
+        # Get the SLX name from the first/current runRequest
+        # The slxName is in format "workspace--slxshortname"
+        slx_name = run_requests[0].get("slxName", "")
+        
+        if not slx_name:
+            BuiltIn().log("No slxName found in runRequest", level="WARN")
+            return None
+        
+        # Extract the short name (remove workspace prefix)
+        if "--" in slx_name:
+            short_name = slx_name.split("--", 1)[1]
+            BuiltIn().log(f"Current SLX short name: {short_name}", level="INFO")
+            return short_name
+        
+        return slx_name
+        
+    except Exception as e:
+        BuiltIn().log(f"Error getting current SLX short name: {str(e)}", level="WARN")
+        return None
+
+
+@keyword("Get Current SLI Interval Seconds")
+def get_current_sli_interval_seconds() -> Optional[int]:
+    """
+    Get the intervalSeconds from the current SLI's spec configuration.
+    
+    Returns the intervalSeconds value from the SLI spec, or None if it cannot be determined.
+    Defaults to 60 seconds if not found.
+    
+    Example:
+        ${interval}=    Get Current SLI Interval Seconds
+        Log    SLI runs every ${interval} seconds
+    """
+    try:
+        from RW.Workspace.workspace_utils import import_platform_variable
+        from RW import platform
+        
+        # Get workspace and API info
+        ws = import_platform_variable("RW_WORKSPACE")
+        root = import_platform_variable("RW_WORKSPACE_API_URL")
+        
+        # Get current SLX short name
+        slx_short_name = get_current_slx_short_name()
+        if not slx_short_name:
+            BuiltIn().log("Could not determine current SLX, defaulting to 60 seconds", level="WARN")
+            return 60
+        
+        # Build authenticated session
+        token = os.getenv("RW_USER_TOKEN")
+        if token:
+            sess = requests.Session()
+            sess.headers.update({
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}",
+            })
+        else:
+            sess = platform.get_authenticated_session()
+        
+        # Handle workspace prefix
+        workspace_path = ws.lstrip('/')
+        if workspace_path.startswith('workspaces/'):
+            workspace_path = workspace_path[len('workspaces/'):]
+        
+        # Fetch the SLX details
+        slx_url = f"{root}/{workspace_path}/slxs/{slx_short_name}"
+        
+        try:
+            response = sess.get(slx_url, timeout=120)
+            response.raise_for_status()
+            slx_data = response.json()
+            
+            # Navigate to sli.spec.intervalSeconds (correct path based on SLX structure)
+            sli_spec = slx_data.get("sli", {}).get("spec", {})
+            interval = sli_spec.get("intervalSeconds")
+            
+            if interval:
+                BuiltIn().log(f"Found SLI interval: {interval} seconds", level="INFO")
+                return int(interval)
+            
+            # Default to 60 if not found
+            BuiltIn().log("intervalSeconds not found in SLI spec, defaulting to 60 seconds", level="INFO")
+            return 60
+            
+        except (requests.RequestException, json.JSONDecodeError) as e:
+            BuiltIn().log(f"Error fetching SLX details: {str(e)}, defaulting to 60 seconds", level="WARN")
+            return 60
+        
+    except Exception as e:
+        BuiltIn().log(f"Error getting SLI interval: {str(e)}, defaulting to 60 seconds", level="WARN")
+        return 60

--- a/libraries/RW/Workspace/workspace_utils.py
+++ b/libraries/RW/Workspace/workspace_utils.py
@@ -384,7 +384,11 @@ def run_tasks_for_slx(slx: str) -> Optional[Dict]:
         tasks = rb.json().get("status", {}).get("codeBundle", {}).get("tasks", [])
     except (requests.RequestException, json.JSONDecodeError) as e:
         warning_log("Runbook fetch failed", str(e))
-        tasks = []
+        return None  # Return None instead of continuing with empty tasks
+    
+    if not tasks:
+        warning_log("No tasks found in runbook", slx)
+        return None
 
     patch_body = {
         "runRequests": [{

--- a/libraries/RW/Workspace/workspace_utils.py
+++ b/libraries/RW/Workspace/workspace_utils.py
@@ -340,8 +340,13 @@ def get_slxs_with_targeted_entity_reference(entity_refs: List[str], tag_types: L
     return hits
 
 
+@keyword("Run Tasks For SLX")
 def run_tasks_for_slx(slx: str) -> Optional[Dict]:
-    """Create a runRequest containing all tasks in the SLX runbook."""
+    """
+    Create a runRequest containing all tasks in the SLX runbook.
+    DEPRECATED: Use Create RunSession For SLX instead for SLIs.
+    This function patches an existing runsession (requires RW_SESSION_ID).
+    """
     try:
         runsess = import_platform_variable("RW_SESSION_ID")
         ws = import_platform_variable("RW_WORKSPACE")
@@ -363,8 +368,16 @@ def run_tasks_for_slx(slx: str) -> Optional[Dict]:
     workspace_path = ws.lstrip('/')
     if workspace_path.startswith('workspaces/'):
         workspace_path = workspace_path[len('workspaces/'):]
+    
+    # Handle case where root might already include "/workspaces" suffix
+    base_url = root.rstrip('/')
+    if base_url.endswith('/workspaces'):
+        rb_url = f"{base_url}/{workspace_path}/slxs/{slx}/runbook"
+        rs_url = f"{base_url}/{workspace_path}/runsessions/{runsess}"
+    else:
+        rb_url = f"{base_url}/workspaces/{workspace_path}/slxs/{slx}/runbook"
+        rs_url = f"{base_url}/workspaces/{workspace_path}/runsessions/{runsess}"
         
-    rb_url = f"{root}/{workspace_path}/slxs/{slx}/runbook"
     try:
         rb = sess.get(rb_url, timeout=120)  # Increased timeout to 120 seconds
         rb.raise_for_status()
@@ -379,13 +392,89 @@ def run_tasks_for_slx(slx: str) -> Optional[Dict]:
             "taskTitles": tasks
         }]
     }
-    rs_url = f"{root}/{workspace_path}/runsessions/{runsess}"
     try:
         rsp = sess.patch(rs_url, json=patch_body, timeout=120)  # Increased timeout to 120 seconds
         rsp.raise_for_status()
         return rsp.json()
     except (requests.RequestException, json.JSONDecodeError) as e:
         warning_log("RunSession patch failed", str(e))
+        return None
+
+
+@keyword("Create RunSession For SLX")
+def create_runsession_for_slx(slx: str, source: str = "cronScheduler") -> Optional[Dict]:
+    """
+    Create a NEW runsession for the given SLX (runs all tasks from its runbook).
+    Does NOT require RW_SESSION_ID - suitable for SLIs that start new runsessions.
+    
+    Args:
+        slx: The SLX short name
+        source: Source identifier (default: "cronScheduler")
+    
+    Returns:
+        The created runsession JSON or None on failure
+    """
+    try:
+        ws = import_platform_variable("RW_WORKSPACE")
+        root = import_platform_variable("RW_WORKSPACE_API_URL")
+    except ImportError:
+        return None
+
+    token = os.getenv("RW_USER_TOKEN")
+    if token:
+        sess = requests.Session()
+        sess.headers.update({
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        })
+    else:
+        sess = platform.get_authenticated_session()
+
+    # Handle case where ws might already include "workspaces/" prefix
+    workspace_path = ws.lstrip('/')
+    if workspace_path.startswith('workspaces/'):
+        workspace_path = workspace_path[len('workspaces/'):]
+    
+    # Handle case where root might already include "/workspaces" suffix
+    base_url = root.rstrip('/')
+    if base_url.endswith('/workspaces'):
+        rb_url = f"{base_url}/{workspace_path}/slxs/{slx}/runbook"
+    else:
+        rb_url = f"{base_url}/workspaces/{workspace_path}/slxs/{slx}/runbook"
+    try:
+        rb = sess.get(rb_url, timeout=120)
+        rb.raise_for_status()
+        tasks = rb.json().get("status", {}).get("codeBundle", {}).get("tasks", [])
+    except (requests.RequestException, json.JSONDecodeError) as e:
+        warning_log("Runbook fetch failed", str(e))
+        return None
+    
+    if not tasks:
+        warning_log("No tasks found in runbook", slx)
+        return None
+    
+    # Build the runsession creation payload
+    body = {
+        "generateName": "cron-scheduled",
+        "runRequests": [{
+            "slxName": f"{workspace_path}--{slx}",
+            "taskTitles": tasks,
+            "fromSearchQuery": source  # Use fromSearchQuery field (compatible with API)
+        }],
+        "active": True
+    }
+    
+    # Create new runsession
+    if base_url.endswith('/workspaces'):
+        rs_url = f"{base_url}/{workspace_path}/runsessions"
+    else:
+        rs_url = f"{base_url}/workspaces/{workspace_path}/runsessions"
+    try:
+        rsp = sess.post(rs_url, json=body, timeout=120)
+        rsp.raise_for_status()
+        return rsp.json()
+    except (requests.RequestException, json.JSONDecodeError) as e:
+        warning_log("RunSession creation failed", str(e))
         return None
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ docker
 azure-containerregistry 
 azure-identity 
 rw-cli-keywords>=0.0.23
+croniter>=1.3.0


### PR DESCRIPTION
- Added `croniter` dependency to `requirements.txt`.
- Imported `slx_utils` in `__init__.py` for better modularity.
- Refactored `run_tasks_for_slx` function to improve URL handling and added deprecation notice.
- Introduced `create_runsession_for_slx` function to facilitate new runsession creation without requiring `RW_SESSION_ID`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a generic cron scheduler SLI that can trigger runbooks on schedules and optionally target other SLXs.
> 
> - New `codebundles/cron-scheduler-sli` with `sli.robot`, README, and examples (supports self/cross-SLX scheduling, dry-run, metrics)
> - New `RW.Cron` library (`cron_utils.py`) for validating/parsing cron and computing next run, backed by `croniter`
> - Workspace utilities: add `Create RunSession For SLX` (POST to create new runsessions) and mark `Run Tasks For SLX` as deprecated; improve URL handling and error paths
> - New `RW.Workspace.slx_utils` to auto-detect current SLX short name and SLI interval seconds
> - Update `requirements.txt` to include `croniter`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 457e18b20a96519fb56abdf08ca43850dc0740d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->